### PR TITLE
docs: Remove aarch64 unsupported note for Homebrew on Linux

### DIFF
--- a/docs/Homebrew-on-Linux.md
+++ b/docs/Homebrew-on-Linux.md
@@ -53,7 +53,7 @@ If you're using an older distribution of Linux, installing your first package wi
 
 - **Linux** 3.2 or newer
 - **Glibc** 2.13 or newer
-- **64-bit x86_64** CPU
+- **64-bit x86_64** or **64-bit aarch64** (including Apple Silicon) CPU's
 
 To install build tools, paste at a terminal prompt:
 
@@ -76,9 +76,9 @@ To install build tools, paste at a terminal prompt:
   sudo pacman -S base-devel procps-ng curl file git
   ```
 
-### ARM (unsupported)
+### ARM32 (unsupported)
 
-Homebrew can run on 32-bit ARM (e.g. Raspberry Pi and others) and 64-bit ARM (ARM64, also known as AArch64), but as they lack bottles (binary packages) they are unsupported. Pull requests are welcome to improve the experience on ARM platforms.
+Homebrew can run on 32-bit ARM (e.g. Raspberry Pi and others), but as they lack bottles (binary packages) they are unsupported. Pull requests are welcome to improve the experience on ARM platforms.
 
 You may need to install your own Ruby using your system package manager, a PPA, or `rbenv/ruby-build` as we no longer distribute a Homebrew Portable Ruby for ARM.
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

After https://github.com/Homebrew/install/pull/963/files merge, Homebrew is working on my Setup in Debian docker image on Apple M1. Since it's fixed, it should be reflected in the docs.

Note, that I cannot test on arm32, but the PR mentioned above was only about 64-bit arch, so for 32-bit platforms the restrictions seems to be still actual